### PR TITLE
Improve creation of subdataset

### DIFF
--- a/CCAgT_utils/constants.py
+++ b/CCAgT_utils/constants.py
@@ -11,3 +11,5 @@ else:  # pragma: <3.8 cover
 VERSION = importlib_metadata.version('CCAgT_utils')
 
 FILENAME_SEP = '_'
+
+STRUCTURE = {'i': 'images/', 'm': 'masks/', 'l': 'CCAgT.parquet.gzip'}

--- a/CCAgT_utils/converters/CCAgT.py
+++ b/CCAgT_utils/converters/CCAgT.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import multiprocessing
 import os
 from typing import Any
@@ -442,6 +443,9 @@ class CCAgT():
             annotations_panoptic.extend(p.get())
 
         return annotations_panoptic
+
+    def copy(self) -> CCAgT:
+        return copy.copy(self)
 
 
 @get_traceback

--- a/CCAgT_utils/converters/CCAgT.py
+++ b/CCAgT_utils/converters/CCAgT.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import multiprocessing
 import os
+import sys
 from typing import Any
 
 import networkx as nx
@@ -391,8 +392,13 @@ class CCAgT():
 
         cpu_num = multiprocessing.cpu_count()
 
+        img_ids = self.df['image_id'].unique()
+        if len(img_ids) == 0:
+            print('Do not have annotations to generate the masks!', file=sys.stderr)
+            return
+
         # Split equals the annotations for the cpu quantity
-        images_ids_splitted = np.array_split(self.df['image_id'].unique(), cpu_num)
+        images_ids_splitted = np.array_split(img_ids, cpu_num)
         print(f'Number of cores: {cpu_num}, images per core: {len(images_ids_splitted[0])}')
 
         workers = multiprocessing.Pool(processes=cpu_num)

--- a/CCAgT_utils/converters/CCAgT.py
+++ b/CCAgT_utils/converters/CCAgT.py
@@ -502,7 +502,8 @@ def read_parquet(filename: str, **kwargs: Any) -> CCAgT:
         raise FileTypeError('The labels file is not a parquet file.')
 
     df = pd.read_parquet(filename, **kwargs)
-    df['geometry'] = df['geometry'].apply(lambda x: shapely.wkt.loads(x))
+    # buffer(0) applied to fix invalid geomtries. From shapely issue #278
+    df['geometry'] = df['geometry'].apply(lambda x: shapely.wkt.loads(x).buffer(0))
 
     return CCAgT(df)
 

--- a/CCAgT_utils/converters/main.py
+++ b/CCAgT_utils/converters/main.py
@@ -81,6 +81,11 @@ def _add_ccagt_to_coco_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--split-by-slide',
                         help='To save the masks into subdirectories for each slide',
                         action='store_true')
+    parser.add_argument('-p',
+                        '--out-precision',
+                        help='The number of digits (decimals), for the coords at output file',
+                        default=2,
+                        metavar='OUTPUT_PRECISION')
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -157,7 +162,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                              aux_path=args.aux_file,
                              out_dir=os.path.abspath(args.output_dir),
                              out_file=args.out_file,
-                             split_by_slide=args.split_by_slide)
+                             split_by_slide=args.split_by_slide,
+                             precision=int(args.out_precision))
 
     elif args.command == 'generate_masks' and args.labels_path != '':
         return ccagt_generate_masks(os.path.abspath(args.labels_path),

--- a/CCAgT_utils/converters/utils.py
+++ b/CCAgT_utils/converters/utils.py
@@ -66,6 +66,7 @@ def __build_description(template: str, df: pd.Dataframe) -> str:
 def __prepare_data(CCAgT_ann: CCAgT,
                    categories_helper_raw: list[dict[str, Any]],
                    image_extension: str) -> None:
+    # TODO: Delete this and use CCAgT_utils.prepare.
     print('\tSearching overlapping and joining labels for overlapping annotations (category id = 5)...')
     overlapping_annotations = CCAgT_ann.find_overlapping_annotations(categories_id={5})
     df = CCAgT_ann.union_geometries(overlapping_annotations)

--- a/CCAgT_utils/converters/utils.py
+++ b/CCAgT_utils/converters/utils.py
@@ -231,8 +231,8 @@ def CCAgT_to_COCO(target: str,
                   aux_path: str | None,
                   out_dir: str,
                   out_file: str | None,
-                  split_by_slide: bool,
-                  precision: int) -> int:
+                  split_by_slide: bool = True,
+                  precision: int = 2) -> int:
     if target in ['INSTANCE-SEGMENTATION', 'IS']:
         raise NotImplementedError
 

--- a/CCAgT_utils/describe.py
+++ b/CCAgT_utils/describe.py
@@ -237,21 +237,24 @@ def dataset(ccagt_path: str,
     images_dir = os.path.join(dataset_dir, STRUCTURE['i'])
     masks_dir = os.path.join(dataset_dir, STRUCTURE['m'])
 
-    desc = ccagt_annotations(ccagt, categories_infos)
     print(f'Dataset name: `{name}` | Location: `{dataset_dir}`')
     print(f'From the annotations file ({ccagt_path}) -')
-    print(f'Quantity of images: {desc["qtd_images"]}')
-    print(f'Quantity of slides: {desc["qtd_slide"]}')
-    print(f'Quantity of annotations: {desc["qtd_annotations"]}')
-    for cat_name, qtd in desc['qtd_annotations_categorical'].items():
-        dist = desc['dist_annotations'][cat_name]
-        print(f' > Quantity of annotations for {cat_name}: {qtd} - {dist*100:.2f}%')
-    print('Statistics of the area of each category...')
-    for cat_name, area_stats in desc['area_stats'].items():
-        print(f' > Statistics of area for {cat_name}: {area_stats}')
+    if ccagt.df.shape[0] == 0:
+        print('Do not have any annotation!')
+    else:
+        desc = ccagt_annotations(ccagt, categories_infos)
+        print(f'Quantity of images: {desc["qtd_images"]}')
+        print(f'Quantity of slides: {desc["qtd_slide"]}')
+        print(f'Quantity of annotations: {desc["qtd_annotations"]}')
+        for cat_name, qtd in desc['qtd_annotations_categorical'].items():
+            dist = desc['dist_annotations'][cat_name]
+            print(f' > Quantity of annotations for {cat_name}: {qtd} - {dist*100:.2f}%')
+        print('Statistics of the area of each category...')
+        for cat_name, area_stats in desc['area_stats'].items():
+            print(f' > Statistics of area for {cat_name}: {area_stats}')
 
-    images_quantity = len(find_files(images_dir, extensions, True))
-    masks_quantity = len(find_files(masks_dir, extensions, True))
-    print('On disk data -')
-    print(f'Total of images: {images_quantity} - at `{images_dir}`')
-    print(f'Total of masks: {masks_quantity} - at `{masks_dir}`')
+        images_quantity = len(find_files(images_dir, extensions, True))
+        masks_quantity = len(find_files(masks_dir, extensions, True))
+        print('On disk data -')
+        print(f'Total of images: {images_quantity} - at `{images_dir}`')
+        print(f'Total of masks: {masks_quantity} - at `{masks_dir}`')

--- a/CCAgT_utils/describe.py
+++ b/CCAgT_utils/describe.py
@@ -14,6 +14,7 @@ from PIL import Image
 
 from CCAgT_utils.categories import Categories
 from CCAgT_utils.categories import CategoriesInfos
+from CCAgT_utils.constants import STRUCTURE
 from CCAgT_utils.converters.CCAgT import CCAgT
 from CCAgT_utils.converters.CCAgT import read_parquet
 from CCAgT_utils.utils import find_files
@@ -233,8 +234,8 @@ def dataset(ccagt_path: str,
     ccagt = read_parquet(ccagt_path)
 
     name = os.path.basename(os.path.normpath(dataset_dir))
-    images_dir = os.path.join(dataset_dir, 'images/')
-    masks_dir = os.path.join(dataset_dir, 'masks/')
+    images_dir = os.path.join(dataset_dir, STRUCTURE['i'])
+    masks_dir = os.path.join(dataset_dir, STRUCTURE['m'])
 
     desc = ccagt_annotations(ccagt, categories_infos)
     print(f'Dataset name: `{name}` | Location: `{dataset_dir}`')

--- a/CCAgT_utils/main.py
+++ b/CCAgT_utils/main.py
@@ -7,10 +7,12 @@ import shutil
 import sys
 from typing import Sequence
 
+from CCAgT_utils import describe
 from CCAgT_utils import slice
-from CCAgT_utils.checkers import masks_that_has
+from CCAgT_utils.categories import CategoriesInfos
 from CCAgT_utils.constants import VERSION
-from CCAgT_utils.prepare import clean_images_and_masks
+from CCAgT_utils.converters.CCAgT import read_parquet
+from CCAgT_utils.converters.utils import ccagt_generate_masks
 from CCAgT_utils.prepare import extract_image_and_mask_by_category
 from CCAgT_utils.utils import basename
 from CCAgT_utils.utils import find_files
@@ -27,7 +29,7 @@ def _add_create_subdataset_options(parser: argparse.ArgumentParser) -> None:
                         metavar='PATH_FOR_ORIGINAL_DATASET',
                         required=True,
                         help=('Path for the original dataset. It is expected that this directory has the subdirectories '
-                              '`images/` and `masks/`'))
+                              '`images/` and `masks/`, and `CCAgT.parquet.gzip`'))
     parser.add_argument('--output',
                         metavar='PATH_TO_WRITE_THE_SUBDATASETS',
                         required=True,
@@ -46,11 +48,9 @@ def _add_create_subdataset_options(parser: argparse.ArgumentParser) -> None:
     group_extract.add_argument('--extract',
                                nargs='*',
                                type=int,
-                               metavar='CATEGORIES IDs',
+                               metavar='CATEGORY ID',
                                help=('Define that wants extract based on one category. Will generate one image for each '
                                      'instance of the desired category.'))
-    group_extract.add_argument('--labels',
-                               help='Path for the CCAgT file with the labels. Just works with --extract')
 
     group_extract.add_argument('--paddings',
                                default=0,
@@ -60,14 +60,14 @@ def _add_create_subdataset_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--remove-images-without',
                         nargs='*',
                         type=int,
-                        metavar='CATEGORIES IDs',
+                        metavar='CATEGORY ID',
                         help=('Define that you wants remove of this subdataset the images that does not have the categories '
                               'passed as argument.'))
 
     group = parser.add_argument_group('Check if all images have at least one of the desired categories.')
     group.add_argument('--check-if-all-have-at-least-one-of',
                        nargs='*',
-                       metavar='CATEGORIES IDs',
+                       metavar='CATEGORY ID',
                        type=int,
                        help=('Define that you wants check if all images have at least one of the categories passed as '
                              'argument.'))
@@ -75,10 +75,33 @@ def _add_create_subdataset_options(parser: argparse.ArgumentParser) -> None:
                        action='store_true',
                        help='To remove all images that do not have at least one of desired categories.')
 
+    group.add_argument('--generate-masks',
+                       action='store_true',
+                       help='To generate the masks for semantic segmentation')
+
+    parser.add_argument('--labels',
+                        help='Path for the CCAgT file with the labels. By default will look at PATH_FOR_ORIGINAL_DATASET')
+
     parser.add_argument('--extensions',
                         nargs='*',
                         default=('.jpg', '.png'),
                         help='The extensions of the images and masks.')
+
+
+STRUCTURE = {'i': 'images/', 'm': 'masks/', 'l': 'CCAgT.parquet.gzip'}
+
+
+def copy_original_dataset(original_images: str,
+                          original_annotations: str,
+                          output_images: str,
+                          output_annotations: str) -> None:
+
+    print('The images and masks of the subdataset will be copied from the original dataset!')
+    print('Coping images files...')
+    shutil.copytree(original_images, output_images)
+
+    print('Coping CCAgT annotations file...')
+    shutil.copy(original_annotations, output_annotations)
 
 
 def create_subdataset(name: str,
@@ -89,26 +112,40 @@ def create_subdataset(name: str,
                       categories_to_keep: set[int] | None,
                       check_if_all_have_one: set[int] | None,
                       delete: bool,
+                      generate_masks: bool,
                       CCAgT_path: str | None,
                       paddings: str,
                       extensions: tuple[str, ...] = ('.jpg', '.png')) -> int:
     output_dir = os.path.join(output_base, name)
-    output_images_dir = os.path.join(output_dir, 'images/')
-    output_masks_dir = os.path.join(output_dir, 'masks/')
+
+    output_images_dir = os.path.join(output_dir, STRUCTURE['i'])
+    output_masks_dir = os.path.join(output_dir, STRUCTURE['m'])
+    output_annotations_path = os.path.join(output_dir, STRUCTURE['l'])
 
     if os.path.isdir(output_images_dir) or os.path.isdir(output_masks_dir):
         print(f'Already exist a dataset with name={name} at {output_base}!', file=sys.stderr)
         return 1
 
-    input_images_dir = os.path.join(original_dir, 'images/')
-    input_masks_dir = os.path.join(original_dir, 'masks/')
+    if CCAgT_path is None:
+        CCAgT_path = os.path.join(original_dir, STRUCTURE['l'])
 
-    if not os.path.isdir(input_images_dir) or not os.path.isdir(input_masks_dir):
-        print(f'Do not found the original dataset at {input_images_dir} or {input_masks_dir}!', file=sys.stderr)
+    input_images_dir = os.path.join(original_dir, STRUCTURE['i'])
+    input_masks_dir = os.path.join(original_dir, STRUCTURE['m'])
+
+    if not os.path.isfile(CCAgT_path):
+        print(f'Not found the annotations file at `{CCAgT_path}`!', file=sys.stderr)
         return 1
 
+    if not os.path.isdir(input_images_dir):
+        print(f'Not found the original data at `{input_images_dir}`!', file=sys.stderr)
+        return 1
+    # elif not os.path.isdir(input_masks_dir):
+    #     print(f'Not found the original data masks at `{input_masks_dir}`!', file=sys.stderr)
+    #     return 1
+
     print('\n\n------------------------')
-    if slice_images:
+    if slice_images is not None:
+        # TODO
         slice_images = tuple(slice_images)
         print(f'Create images and masks splitting then into {slice_images} (horizontal, vertical) parts')
         slice.images_and_masks(input_images_dir,
@@ -117,8 +154,9 @@ def create_subdataset(name: str,
                                slice_images[0], slice_images[1],
                                extension=extensions,
                                look_recursive=True)
-    elif extract:
-        if CCAgT_path:
+    elif extract is not None:
+        # TODO
+        if CCAgT_path is not None:
             print(f'Create images and masks for each instance of the categories {extract}')
             extract_image_and_mask_by_category(input_images_dir,
                                                input_masks_dir,
@@ -132,44 +170,63 @@ def create_subdataset(name: str,
             print('When using `--extract`, please specify the labels files with `--labels` argument', file=sys.stderr)
             return 1
     else:
-        print('The images and masks of the subdataset will be copied from the original dataset!')
-        print('Coping images files...')
-        shutil.copytree(input_images_dir, output_images_dir)
-        print('Coping masks files...')
-        shutil.copytree(input_masks_dir, output_masks_dir)
+        copy_original_dataset(input_images_dir, CCAgT_path, output_images_dir, output_annotations_path)
 
-    if categories_to_keep:
+    ccagt_annotations = read_parquet(output_annotations_path)
+
+    if categories_to_keep is not None:
+        categories_to_keep = set(categories_to_keep)
         print('------------------------')
-        print(f'Delete images that do not have the categories: {categories_to_keep} ')
-        clean_images_and_masks(output_images_dir, output_masks_dir, set(categories_to_keep), extensions)
+        print(f'Delete annotations that with categories different from {categories_to_keep} ')
+        ccagt_annotations.df = ccagt_annotations.df[ccagt_annotations.df['category_id'].isin(categories_to_keep)]
 
-    if check_if_all_have_one:
+    if check_if_all_have_one is not None:
         print('------------------------')
         check_if_all_have_one = set(check_if_all_have_one)
+        if isinstance(categories_to_keep, set):
+            cats_to_have = check_if_all_have_one.union(categories_to_keep)
 
-        masks_with = masks_that_has(output_masks_dir, check_if_all_have_one, extensions, True)
-        all_masks = {basename(k): v for k, v in find_files(output_masks_dir, extensions, True).items()}
-        diff = set(all_masks.keys()) - masks_with
+        images_names = set(ccagt_annotations.df['image_name'].unique())
+        images_names_filtered = set(ccagt_annotations.df.loc[ccagt_annotations.df['category_id'].isin(cats_to_have),
+                                                             'image_name'].unique())
 
+        diff = images_names.difference(images_names_filtered)
         if len(diff) > 0:
-            print(f'A total of {len(diff)} files there is not at least one of the categories {check_if_all_have_one}',
+            print(f'A total of {len(diff)} files there is not at least one of the categories {cats_to_have}',
                   file=sys.stderr)
 
             if delete:
                 all_images = {basename(k): v for k, v in find_files(output_images_dir, extensions, True).items()}
-                print('Deleting images and masks that do not have at least one of the selected categories...')
+                print('Deleting images that do not have at least one of the selected categories...')
                 for bn in diff:
-                    os.remove(all_masks[bn])
                     os.remove(all_images[bn])
+                print('Deleting this images from the annotations...')
+                ccagt_annotations.df = ccagt_annotations.df[ccagt_annotations.df['category_id'].isin(cats_to_have)]
         else:
             print(f'Everything is ok, having 0 files that do not have any of the categories {check_if_all_have_one}')
+
+    print('------------------------')
+    print('Checking if have any image without annotation...')
+    all_images = {basename(k): v for k, v in find_files(output_images_dir, extensions, True).items()}
+    images_with_annotation = set(ccagt_annotations.df['image_name'].unique())
+    diff = set(all_images.keys()).difference(images_with_annotation)
+    if len(diff) > 0:
+        print(f'Deleting total of {len(diff)} images without annotation...')
+        for bn in diff:
+            os.remove(all_images[bn])
+
+    print('------------------------')
+    print(f'Saving the annotations to {output_annotations_path}...')
+    ccagt_annotations.to_parquet(output_annotations_path)
+
+    if generate_masks:
+        print('------------------------')
+        print('Generating masks for semantic segmentation...')
+        ccagt_generate_masks(output_annotations_path, output_masks_dir, True)
+
     print('\n------------------------')
     print('Creation of the subdataset finished!')
-    print(f'Dataset name: `{name}` | Location: `{output_dir}`')
-    images_quantity = len(find_files(output_images_dir, extensions, True))
-    masks_quantity = len(find_files(output_masks_dir, extensions, True))
-    print(f'Total of images: {images_quantity}')
-    print(f'Total of images: {masks_quantity}')
+    describe.dataset(output_annotations_path, CategoriesInfos(), output_dir, extensions)
     return 0
 
 
@@ -211,6 +268,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                                  args.remove_images_without,
                                  args.check_if_all_have_at_least_one_of,
                                  args.delete,
+                                 args.generate_masks,
                                  args.labels,
                                  args.paddings,
                                  tuple(args.extensions))

--- a/CCAgT_utils/main.py
+++ b/CCAgT_utils/main.py
@@ -71,12 +71,12 @@ def _add_create_subdataset_options(parser: argparse.ArgumentParser) -> None:
                                 help=('Define that you wants remove of this subdataset the images that does not have the '
                                       'categories passed as argument.'))
 
-    group_ex_clean.add_argument('--remove-annotations-without',
+    group_ex_clean.add_argument('--remove-annotations-different',
                                 nargs='*',
                                 type=int,
                                 metavar='CATEGORY ID',
-                                help=('Define that you wants remove of this subdataset the annotations that does not have '
-                                      'the categories  passed as argument.'))
+                                help=('Define that you wants remove of this subdataset the annotations that have different '
+                                      'categories then the passed as argument.'))
 
     check_group = parser.add_argument_group('Process of checking the annotation and images.')
     check_group.add_argument('--check-if-all-have-at-least-one-of',
@@ -176,7 +176,7 @@ def create_subdataset(name: str,
 
         elif _choice_to_delete == 1:
             # --remove-annotations-without
-            print(f'Delete annotations that do not have the categories: {_cats_to_keep} ')
+            print(f'Delete annotations that in not in the categories: {_cats_to_keep} ')
             ccagt_annotations.df = ccagt_annotations.df[ccagt_annotations.df['category_id'].isin(_cats_to_keep)]
         else:
             print('Unexpected choice for the type of removal proccess.', file=sys.stderr)
@@ -323,8 +323,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         categories_to_keep = None
         if args.remove_images_without is not None:
             categories_to_keep = (0, set(args.remove_images_without))
-        elif args.remove_annotations_without is not None:
-            categories_to_keep = (1, set(args.remove_annotations_without))
+        elif args.remove_annotations_different is not None:
+            categories_to_keep = (1, set(args.remove_annotations_different))
 
         categories_to_check = None
         if args.check_if_all_have_at_least_one_of is not None:

--- a/CCAgT_utils/main.py
+++ b/CCAgT_utils/main.py
@@ -179,10 +179,11 @@ def create_subdataset(name: str,
         print('No process of remove choiced, just skiping.')
 
     print('------------------------')
-    print(f'Saving the annotations to {output_annotations_path}...')
+    os.makedirs(output_dir, exist_ok=True)
+    print(f'Saving the annotations to `{output_annotations_path}`...')
     ccagt_annotations.to_parquet(output_annotations_path)
 
-    print('\n\n------------------------')
+    print('------------------------')
     if isinstance(slice_images, tuple):
         # --slice-images
         print(f'Create images and masks splitting then into {slice_images} (horizontal, vertical) parts')
@@ -244,9 +245,9 @@ def create_subdataset(name: str,
         else:
             print(f'Everything is ok, have 0 files that do not have any annotation {categories_to_check}')
 
-    if delete and (len(images_without_the_annotations) > 0 or len(images_without_the_annotations) > 0):
+    if delete and (len(images_without_the_annotations) > 0 or len(images_without_the_categories) > 0):
         # --delete
-        if len(images_without_the_annotations) > 0:
+        if len(images_without_the_categories) > 0:
             print(f'Will delete images that do not have at least one of the categories {categories_to_check}')
         if len(images_without_the_annotations) > 0:
             print('Will delete images that do not have at least one annotation')

--- a/CCAgT_utils/main.py
+++ b/CCAgT_utils/main.py
@@ -219,6 +219,7 @@ def create_subdataset(name: str,
     ccagt_annotations = ccagt_dataset(ccagt_annotations, categories_infos, do_fit_geometries=False)
 
     print('------------------------')
+    images_without_the_categories: set[str] = set({})
     if isinstance(categories_to_check, set):
         # --check-if-all-have-at-least-one-of
         images_names = set(ccagt_annotations.df['image_name'].unique())
@@ -233,6 +234,7 @@ def create_subdataset(name: str,
         else:
             print(f'Everything is ok, have 0 files that do not have at least one of the categories {categories_to_check}')
 
+    images_without_the_annotations: set[str] = set({})
     if check_if_images_have_annotations:
         # --no-check-images to skip this
         print('Checking if have any image without annotation...')

--- a/CCAgT_utils/prepare.py
+++ b/CCAgT_utils/prepare.py
@@ -104,14 +104,13 @@ def single_core_extract_image_and_annotations(image_filenames: dict[str, str],
         return [Annotation(row['geometry'], row['category_id']) for _, row in _df.iterrows()]
 
     _c = {Categories.CLUSTER.value, Categories.SATELLITE.value}
+    groups: dict[str, list[set[int]]] = {k: [] for k in ccagt_annotations.df['image_name'].unique()}
     if Categories.NUCLEUS.value in categories_to_extract:
         _c.add(Categories.NUCLEUS.value)
-        groups = ccagt_annotations.find_overlapping_annotations(_c)
+        groups.update(ccagt_annotations.find_overlapping_annotations(_c))
     elif Categories.OVERLAPPED_NUCLEI.value in categories_to_extract:
         _c.add(Categories.OVERLAPPED_NUCLEI.value)
-        groups = ccagt_annotations.find_overlapping_annotations(_c)
-    else:
-        groups = {k: [] for k in ccagt_annotations.df['image_name'].unique()}
+        groups.update(ccagt_annotations.find_overlapping_annotations(_c))
 
     df_filtered = ccagt_annotations.df.loc[ccagt_annotations.df['category_id'].isin(categories_to_extract),
                                            ['image_name', 'geometry', 'category_id']]

--- a/CCAgT_utils/prepare.py
+++ b/CCAgT_utils/prepare.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+from typing import Any
 
 import numpy as np
 import pandas as pd
 from PIL import Image
+from shapely import affinity
 
 from CCAgT_utils.categories import Categories
 from CCAgT_utils.categories import CategoriesInfos
 from CCAgT_utils.checkers import masks_that_has
-from CCAgT_utils.converters import CCAgT
+from CCAgT_utils.converters.CCAgT import CCAgT
+from CCAgT_utils.converters.CCAgT import read_parquet
 from CCAgT_utils.types.annotation import Annotation
 from CCAgT_utils.utils import basename
 from CCAgT_utils.utils import create_structure
@@ -42,73 +45,104 @@ def clean_images_and_masks(dir_images: str,
         os.remove(filename)
 
 
-def extract_category_from_image_file(input_path: str,
-                                     output_path: str,
-                                     annotations: list[Annotation],
-                                     padding: int | float) -> int:
+def extract_category(input_path: str,
+                     output_path: str,
+                     annotations: list[tuple[Annotation, list[Annotation]]],
+                     padding: int | float) -> tuple[int, list[dict[str, Any]]]:
     im = np.asarray(Image.open(input_path))
 
     bn, ext = os.path.splitext(basename(input_path, with_extension=True))
 
     height, width = im.shape[:2]
-
     count = 1
-    for ann in annotations:
-        bb = ann.bbox
-        bb.add_padding(padding, (0, 0, width, height))
-        part = im[bb.slice_y, bb.slice_x]
-        Image.fromarray(part).save(os.path.join(output_path, f'{bn}_{ann.category_id}_{count}{ext}'),
+    annotations_out = []
+    for ann, group in annotations:
+        basename_img = f'{bn}_{ann.category_id}_{count}'
+        filename_img = os.path.join(output_path, f'{basename_img}{ext}')
+
+        bbox = ann.bbox
+        bbox.add_padding(padding, (0, 0, width, height))
+
+        x_off = -1 * bbox.x_init
+        y_off = -1 * bbox.y_init
+
+        ann.geometry = affinity.translate(ann.geometry, x_off, y_off)
+        annotations_out.append({'image_name': basename_img,
+                                'geometry': ann.geometry,
+                                'category_id': ann.category_id})
+
+        for ann_overlapped in group:
+            ann_overlapped.geometry = affinity.translate(ann_overlapped.geometry, x_off, y_off)
+            annotations_out.append({'image_name': basename_img,
+                                    'geometry': ann_overlapped.geometry,
+                                    'category_id': ann_overlapped.category_id})
+
+        part = im[bbox.slice_y, bbox.slice_x]
+        Image.fromarray(part).save(os.path.join(output_path, filename_img),
                                    quality=100,
                                    subsampling=0)
         count += 1
 
-    return len(annotations)
+    return len(annotations), annotations_out
 
 
 @get_traceback
-def single_core_extract_image_and_masks(image_filenames: dict[str, str],
-                                        mask_filenames: dict[str, str],
-                                        df_annotations: pd.DataFrame,
-                                        base_dir_output: str,
-                                        padding: int | float) -> tuple[int, int]:
+def single_core_extract_image_and_annotations(image_filenames: dict[str, str],
+                                              ccagt_annotations: CCAgT,
+                                              categories_to_extract: set[int],
+                                              base_dir_output: str,
+                                              padding: int | float) -> tuple[int, list[dict[str, Any]]]:
+
+    def get_match_group(g: list[set[int]], ann_id: int) -> set[int]:
+        for i in g:
+            if ann_id in i:
+                return i
+        return set({})
+
+    def get_annotations(idx: set[int], ccagt_ann: CCAgT = ccagt_annotations) -> list[Annotation]:
+        _df = ccagt_ann.df[ccagt_ann.df.index.isin(idx)]
+        return [Annotation(row['geometry'], row['category_id']) for _, row in _df.iterrows()]
+
+    _c = {Categories.CLUSTER.value, Categories.SATELLITE.value}
+    if Categories.NUCLEUS.value in categories_to_extract:
+        _c.add(Categories.NUCLEUS.value)
+        groups = ccagt_annotations.find_overlapping_annotations(_c)
+    elif Categories.OVERLAPPED_NUCLEI.value in categories_to_extract:
+        _c.add(Categories.OVERLAPPED_NUCLEI.value)
+        groups = ccagt_annotations.find_overlapping_annotations(_c)
+    else:
+        groups = {k: [] for k in ccagt_annotations.df['image_name'].unique()}
+
+    df_filtered = ccagt_annotations.df.loc[ccagt_annotations.df['category_id'].isin(categories_to_extract),
+                                           ['image_name', 'geometry', 'category_id']]
+
     image_counter = 0
-    mask_counter = 0
-    for bn, sub_df in df_annotations.groupby('image_name'):
+    annotations_out = []
+    for bn, sub_df in df_filtered.groupby('image_name'):
+        ann_items = [(Annotation(row['geometry'], row['category_id']),
+                      get_annotations(get_match_group(groups[bn], idx))) for idx, row in sub_df.iterrows()]
 
-        anns = [Annotation(row['geometry'], row['category_id']) for _, row in sub_df.iterrows()]
-
-        if bn in image_filenames:
-            image_counter += extract_category_from_image_file(image_filenames[bn],
-                                                              os.path.join(base_dir_output, 'images/', slide_from_filename(bn)),
-                                                              anns,
-                                                              padding)
-        if bn in mask_filenames:
-            mask_counter += extract_category_from_image_file(mask_filenames[bn],
-                                                             os.path.join(base_dir_output, 'masks/', slide_from_filename(bn)),
-                                                             anns,
-                                                             padding)
-    return (image_counter, mask_counter)
+        if len(ann_items) > 0:
+            img_counter, ann_out = extract_category(image_filenames[bn],
+                                                    os.path.join(base_dir_output, 'images/', slide_from_filename(bn)),
+                                                    ann_items,
+                                                    padding)
+            image_counter += img_counter
+            annotations_out.extend(ann_out)
+    return (image_counter, annotations_out)
 
 
-def extract_image_and_mask_by_category(dir_images: str,
-                                       dir_masks: str,
-                                       dir_output: str,
-                                       categories: set[int],
-                                       CCAgT_path: str,
-                                       paddings: int | float,
-                                       extension: str | tuple[str, ...] = ('.png', '.jpg'),
-                                       look_recursive: bool = True) -> None:
-    ccagt_annotations = CCAgT.read_parquet(CCAgT_path)
-
-    df = ccagt_annotations.df.loc[ccagt_annotations.df['category_id'].isin(categories),
-                                  ['image_name', 'geometry', 'category_id']]
-
-    if df.empty:
-        print(f'Nothing to process with categories {categories} from {CCAgT_path}')
-        return
+def extract_image_and_annotations_by_category(dir_images: str,
+                                              dir_output: str,
+                                              categories: set[int],
+                                              annotations_path: str,
+                                              paddings: int | float,
+                                              extension: str | tuple[str, ...] = ('.png', '.jpg'),
+                                              look_recursive: bool = True) -> None:
+    ccagt_annotations = read_parquet(annotations_path)
+    ann_qtd = ccagt_annotations.df.shape[0]
 
     image_filenames = {basename(k): v for k, v in find_files(dir_images, extension, look_recursive).items()}
-    mask_filenames = {basename(k): v for k, v in find_files(dir_masks, extension, look_recursive).items()}
 
     slides = {slide_from_filename(i) for i in image_filenames}
     create_structure(dir_output, slides)
@@ -116,36 +150,46 @@ def extract_image_and_mask_by_category(dir_images: str,
     cpu_num = multiprocessing.cpu_count()
     workers = multiprocessing.Pool(processes=cpu_num)
 
-    filenames_splitted = np.array_split(df['image_name'].unique().tolist(), cpu_num)
-    print(f'Start the extraction of each category instance at {len(image_filenames)} images/masks using {cpu_num} cores with '
-          f'{len(filenames_splitted[0])} images/masks per core...')
+    filenames_splitted = np.array_split(ccagt_annotations.df['image_name'].unique(), cpu_num)
+    print(f'Start the extraction of each category instance at {len(image_filenames)} images/annotations using {cpu_num} '
+          f'cores with {len(filenames_splitted[0])} images/annotations per core...')
 
     processes = []
     for filenames in filenames_splitted:
+        if len(filenames) == 0:
+            continue
+
         img_filenames = {k: image_filenames[k] for k in filenames}
-        msk_filenames = {k: mask_filenames[k] for k in filenames}
-        p = workers.apply_async(single_core_extract_image_and_masks, (img_filenames,
-                                                                      msk_filenames,
-                                                                      df[df['image_name'].isin(filenames)],
-                                                                      dir_output,
-                                                                      paddings))
+        _ccagt = ccagt_annotations.copy()
+        _ccagt.df = _ccagt.df[_ccagt.df['image_name'].isin(filenames)]
+
+        p = workers.apply_async(single_core_extract_image_and_annotations, (img_filenames,
+                                                                            _ccagt,
+                                                                            categories,
+                                                                            dir_output,
+                                                                            paddings))
         processes.append(p)
 
     image_counter = 0
-    mask_counter = 0
+    ann_out = []
     for p in processes:
-        im_counter, msk_counter = p.get()
+        im_counter, _ann_out = p.get()
         image_counter += im_counter
-        mask_counter += msk_counter
+        ann_out.extend(_ann_out)
 
-    print(f'Successful create {image_counter}/{mask_counter} images/masks for the instances of the categories {categories}')
+    print('Creating the annotation file...')
+    ccagt_out = CCAgT(pd.DataFrame(ann_out))
+    ccagt_out.to_parquet(annotations_path)
+
+    print(f'Successful created {len(image_filenames)}/{ann_qtd} images/annotations into {image_counter}/{len(ann_out)}'
+          ' images/annotations')
 
 
-def ccagt_dataset(ccagt: CCAgT.CCAgT,
+def ccagt_dataset(ccagt: CCAgT,
                   categories_infos: CategoriesInfos,
                   image_extension: str = '',
                   do_fit_geometries: bool = True
-                  ) -> CCAgT.CCAgT:
+                  ) -> CCAgT:
     print('Start the preprocessing default pipeline for CCAGgT dataset...')
     ovlp_ncl = Categories.OVERLAPPED_NUCLEI.value
     sat = Categories.SATELLITE.value

--- a/CCAgT_utils/prepare.py
+++ b/CCAgT_utils/prepare.py
@@ -121,13 +121,12 @@ def single_core_extract_image_and_annotations(image_filenames: dict[str, str],
         ann_items = [(Annotation(row['geometry'], row['category_id']),
                       get_annotations(get_match_group(groups[bn], idx))) for idx, row in sub_df.iterrows()]
 
-        if len(ann_items) > 0:
-            img_counter, ann_out = extract_category(image_filenames[bn],
-                                                    os.path.join(base_dir_output, 'images/', slide_from_filename(bn)),
-                                                    ann_items,
-                                                    padding)
-            image_counter += img_counter
-            annotations_out.extend(ann_out)
+        img_counter, ann_out = extract_category(image_filenames[bn],
+                                                os.path.join(base_dir_output, 'images/', slide_from_filename(bn)),
+                                                ann_items,
+                                                padding)
+        image_counter += img_counter
+        annotations_out.extend(ann_out)
     return (image_counter, annotations_out)
 
 
@@ -229,7 +228,7 @@ def ccagt_dataset(ccagt: CCAgT,
     df_base_intersects_target = ccagt.verify_if_intersects(base_categories_id={ncl}, target_categories_id={cur, sat})
     if not df_base_intersects_target.empty:
         index_to_drop = df_base_intersects_target[~df_base_intersects_target['has_intersecting']].index.to_numpy()
-        print(f'A total of {len(index_to_drop)} of nuclei (category id = {ncl}) will be deleted.')
+        print(f'A total of {len(index_to_drop)} nuclei without NORs (category id = {ncl}) will be deleted.')
         df.drop(index_to_drop, inplace=True)
 
     print(f'Searching intersections of NORs with nuclei (normal and overlapped) labels (category id in [{cur}, {sat}] and '
@@ -237,7 +236,7 @@ def ccagt_dataset(ccagt: CCAgT,
     df_base_intersects_target = ccagt.verify_if_intersects(base_categories_id={cur, sat}, target_categories_id={ncl, ovlp_ncl})
     if not df_base_intersects_target.empty:
         index_to_drop = df_base_intersects_target[~df_base_intersects_target['has_intersecting']].index.to_numpy()
-        print(f'A total of {len(index_to_drop)} of NORs (category id =  [{cur}, {sat}]) will be deleted.')
+        print(f'A total of {len(index_to_drop)} NORs without Nucleus (category id =  [{cur}, {sat}]) will be deleted.')
         df.drop(index_to_drop, inplace=True)
 
     return ccagt

--- a/CCAgT_utils/prepare.py
+++ b/CCAgT_utils/prepare.py
@@ -155,7 +155,7 @@ def extract_image_and_annotations_by_category(dir_images: str,
     processes = []
     for filenames in filenames_splitted:
         if len(filenames) == 0:
-            continue
+            continue  # pragma: no cover
 
         img_filenames = {k: image_filenames[k] for k in filenames}
         _ccagt = ccagt_annotations.copy()

--- a/CCAgT_utils/slice.py
+++ b/CCAgT_utils/slice.py
@@ -117,14 +117,13 @@ def single_core_image_and_annotations(image_filenames: dict[str, str],
     for bn, df in df_ccagt.groupby('image_name'):
         ann_items = [Annotation(r['geometry'], r['category_id']) for _, r in df.iterrows()]
 
-        if len(ann_items) > 0:
-            img_counter, ann_out = image_with_annotation(image_filenames[bn],
-                                                         os.path.join(base_dir_output, 'images/', slide_from_filename(bn)),
-                                                         ann_items,
-                                                         h_quantity,
-                                                         v_quantity)
-            image_counter += img_counter
-            annotations_out.extend(ann_out)
+        img_counter, ann_out = image_with_annotation(image_filenames[bn],
+                                                     os.path.join(base_dir_output, 'images/', slide_from_filename(bn)),
+                                                     ann_items,
+                                                     h_quantity,
+                                                     v_quantity)
+        image_counter += img_counter
+        annotations_out.extend(ann_out)
     return (image_counter, annotations_out)
 
 

--- a/CCAgT_utils/slice.py
+++ b/CCAgT_utils/slice.py
@@ -151,7 +151,7 @@ def images_and_annotations(dir_images: str,
     processes = []
     for filenames in filenames_splitted:
         if len(filenames) == 0:
-            continue
+            continue  # pragma: no cover
 
         _ccagt = ccagt.df[ccagt.df['image_name'].isin(filenames)]
         img_filenames = {k: image_filenames[k] for k in filenames}

--- a/CCAgT_utils/slice.py
+++ b/CCAgT_utils/slice.py
@@ -115,12 +115,12 @@ def single_core_image_and_annotations(image_filenames: dict[str, str],
     image_counter = 0
     annotations_out = []
     for bn, df in df_ccagt.groupby('image_name'):
-        anns_items = [Annotation(r['geometry'], r['category_id']) for _, r in df.iterrows()]
+        ann_items = [Annotation(r['geometry'], r['category_id']) for _, r in df.iterrows()]
 
-        if len(anns_items) > 0:
+        if len(ann_items) > 0:
             img_counter, ann_out = image_with_annotation(image_filenames[bn],
                                                          os.path.join(base_dir_output, 'images/', slide_from_filename(bn)),
-                                                         anns_items,
+                                                         ann_items,
                                                          h_quantity,
                                                          v_quantity)
             image_counter += img_counter

--- a/CCAgT_utils/slice.py
+++ b/CCAgT_utils/slice.py
@@ -3,15 +3,28 @@ from __future__ import annotations
 import multiprocessing
 import os
 from typing import Any
+from typing import Iterator
 
 import numpy as np
+import pandas as pd
 from PIL import Image
+from shapely import affinity
 
+from CCAgT_utils.converters.CCAgT import CCAgT
+from CCAgT_utils.converters.CCAgT import read_parquet
+from CCAgT_utils.types.annotation import Annotation
+from CCAgT_utils.types.annotation import BBox
 from CCAgT_utils.utils import basename
 from CCAgT_utils.utils import create_structure
 from CCAgT_utils.utils import find_files
 from CCAgT_utils.utils import get_traceback
 from CCAgT_utils.utils import slide_from_filename
+
+
+def __create_xy_slice(height: int, width: int, tile_h: int, tile_w: int) -> Iterator[BBox]:
+    for y in range(0, height, tile_h):
+        for x in range(0, width, tile_w):
+            yield BBox(x, y, tile_w, tile_h, -1)
 
 
 def image(input_path: str,
@@ -23,80 +36,143 @@ def image(input_path: str,
     bn, ext = os.path.splitext(basename(input_path, with_extension=True))
 
     height, width = im.shape[:2]
-
     tile_h = height // v_quantity
     tile_w = width // h_quantity
-
     count = 1
-    for y in range(0, height, tile_h):
-        for x in range(0, width, tile_w):
-            part = im[y:y + tile_h, x:x + tile_w]
-            Image.fromarray(part).save(os.path.join(output_path, f'{bn}_{count}{ext}'),
-                                       quality=100,
-                                       subsampling=0)
-            count += 1
+    for bbox in __create_xy_slice(height, width, tile_h, tile_w):
+        part = im[bbox.slice_y, bbox.slice_x]
+        Image.fromarray(part).save(os.path.join(output_path, f'{bn}_{count}{ext}'),
+                                   quality=100,
+                                   subsampling=0)
+        count += 1
 
     return count - 1
 
 
+def image_with_annotation(input_path: str,
+                          output_path: str,
+                          annotation_items: list[Annotation],
+                          h_quantity: int = 4,
+                          v_quantity: int = 4) -> tuple[int, list[dict[str, Any]]]:
+    im = np.asarray(Image.open(input_path))
+
+    bn, ext = os.path.splitext(basename(input_path, with_extension=True))
+
+    height, width = im.shape[:2]
+
+    tile_h = height // v_quantity
+    tile_w = width // h_quantity
+
+    ann_to_ignore = []
+    count = 1
+    annotations_out = []
+    for bbox in __create_xy_slice(height, width, tile_h, tile_w):
+        basename_img = f'{bn}_{count}'
+        filename_img = os.path.join(output_path, f'{basename_img}{ext}')
+        bbox_pol = bbox.to_polygon()
+        x_off = -1 * bbox.x_init
+        y_off = -1 * bbox.y_init
+        img_annotations = []
+        for idx, ann in enumerate(annotation_items):
+            if idx in ann_to_ignore:
+                continue
+
+            _test = False
+            ann_to_use = ann.copy()
+            if bbox_pol.contains(ann.geometry):
+                ann_to_ignore.append(idx)
+                _test = True
+            elif ann.geometry.intersects(bbox_pol):
+                ann_to_use.geometry = ann.geometry.intersection(bbox_pol)
+                _test = True
+
+            if _test:
+                ann_to_use.geometry = affinity.translate(ann_to_use.geometry, x_off, y_off)
+                img_annotations.append({'image_name': basename_img,
+                                        'geometry': ann_to_use.geometry,
+                                        'category_id': ann_to_use.category_id})
+
+        if len(img_annotations) > 0:
+            annotations_out.extend(img_annotations)
+            part = im[bbox.slice_y, bbox.slice_x]
+            Image.fromarray(part).save(filename_img,
+                                       quality=100,
+                                       subsampling=0)
+            count += 1
+
+        if len(annotation_items) == len(ann_to_ignore):
+            break
+
+    return (count - 1, annotations_out)
+
+
 @get_traceback
-def single_core_image_and_masks(image_filenames: dict[str, str],
-                                mask_filenames: dict[str, str],
-                                base_dir_output: str,
-                                h_quantity: int = 4,
-                                v_quantity: int = 4) -> tuple[int, int]:
+def single_core_image_and_annotations(image_filenames: dict[str, str],
+                                      df_ccagt: pd.DataFrame,
+                                      base_dir_output: str,
+                                      h_quantity: int = 4,
+                                      v_quantity: int = 4) -> tuple[int, list[dict[str, Any]]]:
     image_counter = 0
-    mask_counter = 0
-    for bn in image_filenames:
-        image_counter += image(image_filenames[bn],
-                               os.path.join(base_dir_output, 'images/', slide_from_filename(bn)),
-                               h_quantity,
-                               v_quantity)
+    annotations_out = []
+    for bn, df in df_ccagt.groupby('image_name'):
+        anns_items = [Annotation(r['geometry'], r['category_id']) for _, r in df.iterrows()]
 
-        if bn in mask_filenames:
-            mask_counter += image(mask_filenames[bn],
-                                  os.path.join(base_dir_output, 'masks/', slide_from_filename(bn)),
-                                  h_quantity,
-                                  v_quantity)
+        if len(anns_items) > 0:
+            img_counter, ann_out = image_with_annotation(image_filenames[bn],
+                                                         os.path.join(base_dir_output, 'images/', slide_from_filename(bn)),
+                                                         anns_items,
+                                                         h_quantity,
+                                                         v_quantity)
+            image_counter += img_counter
+            annotations_out.extend(ann_out)
+    return (image_counter, annotations_out)
 
-    return (image_counter, mask_counter)
 
-
-def images_and_masks(dir_images: str,
-                     dir_masks: str,
-                     dir_output: str,
-                     h_quantity: int = 4,
-                     v_quantity: int = 4,
-                     **kwargs: Any) -> None:
+def images_and_annotations(dir_images: str,
+                           annotations_path: str,
+                           dir_output: str,
+                           output_annotations_path: str,
+                           h_quantity: int = 4,
+                           v_quantity: int = 4,
+                           **kwargs: Any) -> None:
 
     image_filenames = {basename(k): v for k, v in find_files(dir_images, **kwargs).items()}
-    mask_filenames = {basename(k): v for k, v in find_files(dir_masks, **kwargs).items()}
 
+    ccagt = read_parquet(annotations_path)
+    ann_qtd = ccagt.df.shape[0]
     slides = {slide_from_filename(i) for i in image_filenames}
     create_structure(dir_output, slides)
 
     cpu_num = multiprocessing.cpu_count()
     workers = multiprocessing.Pool(processes=cpu_num)
     filenames_splitted = np.array_split(list(image_filenames), cpu_num)
-    print(f'Start the split of images and masks into {h_quantity}x{v_quantity} parts using {cpu_num} cores with '
+    print(f'Start the split of images and annotations into {h_quantity}x{v_quantity} parts using {cpu_num} cores with '
           f'{len(filenames_splitted[0])} images and masks per core...')
+
     processes = []
     for filenames in filenames_splitted:
+        if len(filenames) == 0:
+            continue
+
+        _ccagt = ccagt.df[ccagt.df['image_name'].isin(filenames)]
         img_filenames = {k: image_filenames[k] for k in filenames}
-        msk_filenames = {k: mask_filenames[k] for k in filenames}
-        p = workers.apply_async(single_core_image_and_masks, (img_filenames,
-                                                              msk_filenames,
-                                                              dir_output,
-                                                              h_quantity,
-                                                              v_quantity))
+        p = workers.apply_async(single_core_image_and_annotations, (img_filenames,
+                                                                    _ccagt,
+                                                                    dir_output,
+                                                                    h_quantity,
+                                                                    v_quantity))
         processes.append(p)
 
     image_counter = 0
-    mask_counter = 0
+    ann_out = []
     for p in processes:
-        im_counter, msk_counter = p.get()
+        im_counter, _ann_out = p.get()
         image_counter += im_counter
-        mask_counter += msk_counter
+        ann_out.extend(_ann_out)
 
-    print(f'Successful splitted {len(image_filenames)}/{len(mask_filenames)} images/masks into {image_counter}/{mask_counter}'
-          ' images/masks')
+    print('Creating the annotation file...')
+    ccagt_out = CCAgT(pd.DataFrame(ann_out))
+    ccagt_out.to_parquet(output_annotations_path)
+
+    print(f'Successful splitted {len(image_filenames)}/{ann_qtd} images/annotations into {image_counter}/{len(ann_out)}'
+          ' images/annotations')

--- a/CCAgT_utils/types/annotation.py
+++ b/CCAgT_utils/types/annotation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+from copy import copy
 from dataclasses import dataclass
 
 from shapely.geometry import MultiPolygon
@@ -50,6 +51,9 @@ class Annotation:
             return out
         else:
             raise StopIteration
+
+    def copy(self) -> Annotation:
+        return copy(self)
 
 
 @dataclass

--- a/CCAgT_utils/utils.py
+++ b/CCAgT_utils/utils.py
@@ -8,6 +8,7 @@ from typing import Callable
 from typing import TypeVar
 
 from CCAgT_utils.constants import FILENAME_SEP
+from CCAgT_utils.constants import STRUCTURE
 
 R = TypeVar('R')
 
@@ -141,8 +142,8 @@ def find_files(dir_path: str,
 
 def create_structure(dir_path: str, slides: set[str]) -> None:
 
-    dir_images = os.path.join(dir_path, 'images/')
-    dir_masks = os.path.join(dir_path, 'masks/')
+    dir_images = os.path.join(dir_path, STRUCTURE['i'])
+    dir_masks = os.path.join(dir_path, STRUCTURE['m'])
 
     for slide in slides:
         os.makedirs(os.path.join(dir_images, slide), exist_ok=True)

--- a/testing/create.py
+++ b/testing/create.py
@@ -9,10 +9,11 @@ import numpy as np
 from PIL import Image
 
 
-def row_CCAgT(obj: Any, cat: int, name: str) -> dict[str, Any]:
+def row_CCAgT(obj: Any, cat: int, name: str, **kwargs: Any) -> dict[str, Any]:
     return {'image_name': name,
             'geometry': obj,
-            'category_id': cat}
+            'category_id': cat,
+            **kwargs}
 
 
 def mask_categorical(shape: tuple[int, int]) -> np.ndarray:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
+from shapely import affinity
 from shapely.geometry import Point
 from shapely.geometry import Polygon
 
@@ -219,11 +220,19 @@ def lbb_raw_expected_ccagt_df(satellite_ex, nucleus_ex):
 @pytest.fixture
 def ccagt_df_multi(nucleus_ex, cluster_ex, satellite_ex):
     # Using a dict with a list for each collum, will raise a warning for Points because of pandas cast type
-    d = [create.row_CCAgT(satellite_ex, 3, 'A_xx1'),
-         create.row_CCAgT(nucleus_ex, 1, 'A_xx1'),
-         create.row_CCAgT(cluster_ex, 2, 'A_xx1'),
-         create.row_CCAgT(nucleus_ex, 1, 'B_xx1'),
-         create.row_CCAgT(nucleus_ex, 1, 'B_xx1')]
+    d = [create.row_CCAgT(satellite_ex, 3, 'A_xx1', image_id=1),
+         create.row_CCAgT(nucleus_ex, 1, 'A_xx1', image_id=1),
+         create.row_CCAgT(cluster_ex, 2, 'A_xx1', image_id=1),
+
+         create.row_CCAgT(nucleus_ex, 1, 'B_xx1', image_id=2),
+         create.row_CCAgT(affinity.translate(nucleus_ex, 50, 50), 1, 'B_xx1', image_id=2),
+
+         create.row_CCAgT(satellite_ex, 3, 'A_yy2', image_id=3),
+         create.row_CCAgT(nucleus_ex, 1, 'A_yy2', image_id=3),
+         create.row_CCAgT(cluster_ex, 2, 'A_yy2', image_id=3),
+         create.row_CCAgT(affinity.translate(satellite_ex, 50, 50), 3, 'A_yy2', image_id=3),
+         create.row_CCAgT(affinity.translate(nucleus_ex, 50, 50), 1, 'A_yy2', image_id=3),
+         create.row_CCAgT(affinity.translate(cluster_ex, 50, 50), 2, 'A_yy2', image_id=3)]
     return pd.DataFrame(d)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -118,7 +120,7 @@ def nucleus_ex():
 
 @pytest.fixture
 def cluster_ex():
-    return Polygon([(10, 10), (10, 15), (15, 15), (15, 10)])
+    return Polygon([(10, 10), (10, 25), (25, 25), (25, 10)])
 
 
 @pytest.fixture
@@ -129,7 +131,7 @@ def annotations_ex(nucleus_ex, cluster_ex):
 @pytest.fixture
 def cluster_mask_ex():
     out = np.zeros((20, 20), dtype=np.uint8)
-    out[10:16, 10:16] = 2
+    out[10:26, 10:26] = 2
     return out
 
 
@@ -239,6 +241,18 @@ def ccagt_ann_single_nucleus(nucleus_ex):
 @pytest.fixture
 def ccagt_ann_multi(ccagt_df_multi):
     return CCAgT.CCAgT(ccagt_df_multi)
+
+
+@pytest.fixture
+def ccagt_ann_multi_image_names(ccagt_ann_multi):
+    return ccagt_ann_multi.df['image_name'].unique().tolist()
+
+
+@pytest.fixture
+def ccagt_ann_multi_path(ccagt_ann_multi, tmpdir):
+    path = os.path.join(tmpdir, 'CCAgT.parquet.gzip')
+    ccagt_ann_multi.to_parquet(path)
+    return path
 
 
 @pytest.fixture

--- a/tests/converters/CCAgT_test.py
+++ b/tests/converters/CCAgT_test.py
@@ -92,7 +92,7 @@ def test_geometries_area(ccagt_ann_single_nucleus, nucleus_ex):
 
 def test_generate_ids(ccagt_ann_multi):
     img_name_series = ccagt_ann_multi.df['image_name']
-    assert ccagt_ann_multi.generate_ids(img_name_series).tolist() == [1, 1, 1, 2, 2]
+    assert ccagt_ann_multi.generate_ids(img_name_series).tolist() == [1, 1, 1, 3, 3, 2, 2, 2, 2, 2, 2]
 
 
 @pytest.mark.parametrize('min_area,expected,compute_area', [(99999, 0, False),
@@ -113,7 +113,7 @@ def test_delete_by_area_ignore_ids(ccagt_ann_multi):
                                         {'name': 'Satellite', 'id': 3, 'color': (0, 0, 0), 'minimal_area': 0},
                                         {'name': 'Nucleus_out_of_focus', 'id': 4, 'color': (0, 0, 0), 'minimal_area': 0}])
     df = ccagt_ann_multi.delete_by_area(categories_infos, set({2, 3}))
-    assert df.shape[0] == 2
+    assert df.shape[0] == 6
 
 
 def test_find_intersecting_geometries(ccagt_ann_multi, cluster_ex):
@@ -141,18 +141,18 @@ def test_has_intersecting_geometries(ccagt_ann_multi, cluster_ex):
 
 def test_verify_if_intersects(ccagt_ann_multi):
     df = ccagt_ann_multi.verify_if_intersects(set({1}), set({2}))
-    assert df['has_intersecting'].tolist() == [True, False, False]
+    assert df['has_intersecting'].tolist() == [True, True, True, False, False]
 
     df = ccagt_ann_multi.verify_if_intersects(set({1}), None)
-    assert df['has_intersecting'].tolist() == [True, True, True]
+    assert df['has_intersecting'].tolist() == [True] * 5
 
 
 def test_find_overlapping_annotations(ccagt_ann_multi):
     groups = ccagt_ann_multi.find_overlapping_annotations(set({1, 2}))
-    assert groups == {'A_xx1': [{1, 2}], 'B_xx1': [{3, 4}]}
+    assert groups == {'A_xx1': [{1, 2}], 'A_yy2': [{6, 7}, {9, 10}]}
 
     groups = ccagt_ann_multi.find_overlapping_annotations(set({1, 2}), True)
-    assert groups == {'A_xx1': [{1, 2}], 'B_xx1': [{3, 4}]}
+    assert groups == {'A_xx1': [{1, 2}], 'A_yy2': [{6, 7}, {9, 10}]}
 
     groups = ccagt_ann_multi.find_overlapping_annotations(set({3}), True)
     assert groups == {}

--- a/tests/converters/utils_test.py
+++ b/tests/converters/utils_test.py
@@ -22,9 +22,9 @@ def test_build_description(ccagt_df_multi, ccagt_metadata):
 
     out = utils.__build_description(template, df)
     assert out == '''
-qtd of images = 2
+qtd of images = 3
 qtd of slides = 2
-qtd of annotations = 5
+qtd of annotations = 11
 '''
 
 

--- a/tests/converters/utils_test.py
+++ b/tests/converters/utils_test.py
@@ -139,10 +139,6 @@ def test_CCAgT_to_PS_COCO(ccagt_ann_single_nucleus, categories_infos, tmpdir):
 
 
 def test_CCAgT_to_COCO_NotImplemented():
-
-    with pytest.raises(NotImplementedError):
-        utils.CCAgT_to_COCO('OD', '', None, '', None, False)
-
     with pytest.raises(NotImplementedError):
         utils.CCAgT_to_COCO('IS', '', None, '', None, False)
 
@@ -155,6 +151,18 @@ def test_CCAgT_to_COCO_PS_with_auxfile(ccagt_ann_single_nucleus, ccagt_aux_data)
         ccagt_path = os.path.join(temp_dir, 'ccagt.parquet.gzip')
         ccagt_ann_single_nucleus.to_parquet(ccagt_path)
         out = utils.CCAgT_to_COCO('PS', ccagt_path, aux_path, temp_dir, None, False)
+
+        assert out == 0
+
+
+def test_CCAgT_to_COCO_OD_with_auxfile(ccagt_ann_single_nucleus, ccagt_aux_data):
+    ccagt_ann_single_nucleus.df['image_name'] = 'C_xx1'
+
+    with RawAuxFiles([{'a': None}], ccagt_aux_data) as paths:
+        temp_dir, _, aux_path = paths
+        ccagt_path = os.path.join(temp_dir, 'ccagt.parquet.gzip')
+        ccagt_ann_single_nucleus.to_parquet(ccagt_path)
+        out = utils.CCAgT_to_COCO('OD', ccagt_path, aux_path, temp_dir, None, False)
 
         assert out == 0
 

--- a/tests/describe_test.py
+++ b/tests/describe_test.py
@@ -93,8 +93,8 @@ def test_annotations_per_image(ccagt_ann_multi, categories_infos):
     ccagt_ann_multi.df['image_id'] = ccagt_ann_multi.generate_ids(ccagt_ann_multi.df['image_name'])
     df = describe.annotations_per_image(ccagt_ann_multi, categories_infos)
 
-    assert df['NORs'].tolist() == [2., 0.]
-    assert df['count', 'NUCLEUS'].tolist() == [1., 2.]
+    assert df['NORs'].tolist() == [2., 4., 0.]
+    assert df['count', 'NUCLEUS'].tolist() == [1., 2., 2.]
 
 
 def test_ccagt_annotations(ccagt_ann_multi, categories_infos):
@@ -104,13 +104,14 @@ def test_ccagt_annotations(ccagt_ann_multi, categories_infos):
 
     out = describe.ccagt_annotations(ccagt_ann_multi, categories_infos)
 
-    assert out['qtd_images'] == 2
+    assert out['qtd_images'] == 3
     assert out['qtd_slide'] == 2
-    assert out['qtd_annotations'] == 5
-    assert out['qtd_annotations_categorical'] == {'Nucleus': 3, 'Cluster': 1, 'Satellite': 1, 'Nucleus_out_of_focus': 0,
+    assert out['qtd_annotations'] == ccagt_ann_multi.df.shape[0]
+    assert out['qtd_annotations_categorical'] == {'Nucleus': 5, 'Cluster': 3, 'Satellite': 3, 'Nucleus_out_of_focus': 0,
                                                   'Overlapped_Nuclei': 0, 'non_viable_nucleus': 0, 'Leukocyte_Nucleus': 0,
                                                   'background': 0}
-    assert out['dist_annotations'] == {'Nucleus': 0.6, 'Cluster': 0.2, 'Satellite': 0.2, 'Nucleus_out_of_focus': 0.0,
+    assert out['dist_annotations'] == {'Nucleus': pytest.approx(0.454, 0.01), 'Cluster': pytest.approx(0.273, 0.01),
+                                       'Satellite': pytest.approx(0.273, 0.01), 'Nucleus_out_of_focus': 0.0,
                                        'Overlapped_Nuclei': 0.0, 'non_viable_nucleus': 0.0, 'Leukocyte_Nucleus': 0.0,
                                        'background': 0.0}
     assert len(out['area_stats']) == 3
@@ -128,8 +129,8 @@ def test_tvt_annotations_as_df(ccagt_ann_multi, categories_infos):
     assert df_qtd.shape[0] == 4
     assert df_qtd.shape[1] == len(categories_infos) + 4
     assert df_qtd.loc[df_qtd['fold'] == 'total'].shape[0] == 1
-    assert df_qtd['images'].tolist() == [2, 2, 2, 6]
-    assert df_qtd['annotations'].tolist() == [5, 5, 5, 15]
+    assert df_qtd['images'].tolist() == [3, 3, 3, 9]
+    assert df_qtd['annotations'].tolist() == [11, 11, 11, 33]
 
     assert df_dist.shape[0] == 3
     assert df_dist.shape[1] == len(categories_infos) + 3
@@ -140,4 +141,4 @@ def test_tvt_annotations_as_df(ccagt_ann_multi, categories_infos):
 
     cats_with_data = sum(True for v in out['qtd_annotations_categorical'].values() if v > 0)
     assert df_area.shape == (15, 1 + cats_with_data)
-    assert df_area.loc[df_area['fold'] == 'train', 'Nucleus'].tolist() == [900., 0., 900., 900., 3.]
+    assert df_area.loc[df_area['fold'] == 'train', 'Nucleus'].tolist() == [900., 0., 900., 900., 5.]

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,33 +1,57 @@
 from __future__ import annotations
 
+import os
+import shutil
+
 import pytest
 
 from CCAgT_utils import main
 from testing import create
 
 
-def test_create_subdataset(capsys, ccagt_ann_multi_path, shape):
-    with create.ImageMaskFiles(shape[0], shape[1], ['A_example']) as paths:
-        tmp_dir, mask_dir, _ = paths
-        out = main.create_subdataset(name='test',
-                                     original_dir=tmp_dir,
-                                     output_base=tmp_dir,
-                                     slice_images=None,
-                                     extract=None,
-                                     categories_to_keep=None,
-                                     categories_to_check=None,
-                                     delete=False,
-                                     generate_masks=False,
-                                     CCAgT_path=ccagt_ann_multi_path,
-                                     paddings='0',
-                                     check_if_images_have_annotations=False,
-                                     extensions=('.png', '.jpg'),
-                                     aux_file_path=None,
-                                     overwrite=False)
+def test_create_subdataset(capsys, ccagt_ann_multi, ccagt_ann_multi_path, ccagt_ann_multi_image_names, shape, ccagt_aux_data):
+    with create.ImageMaskFiles(shape[0], shape[1], ccagt_ann_multi_image_names) as paths:
+        tmp_dir, mask_dir, img_dir = paths
+        with create.RawAuxFiles([], ccagt_aux_data) as paths:
+            _, _, aux_path = paths
+            out = main.create_subdataset(name='test',
+                                         original_dir=tmp_dir,
+                                         output_base=tmp_dir,
+                                         slice_images=None,
+                                         extract=None,
+                                         categories_to_keep=(0, {1}),
+                                         categories_to_check={1, 2},
+                                         delete=True,
+                                         generate_masks=True,
+                                         CCAgT_path=ccagt_ann_multi_path,
+                                         paddings='0',
+                                         check_if_images_have_annotations=True,
+                                         extensions=('.png', '.jpg'),
+                                         aux_file_path=aux_path,
+                                         overwrite=False)
 
-        assert out == 0
-        _, _ = capsys.readouterr()
+            assert out == 0
+            _, _ = capsys.readouterr()
 
+            out = main.create_subdataset(name='test',
+                                         original_dir=tmp_dir,
+                                         output_base=tmp_dir,
+                                         slice_images=None,
+                                         extract=None,
+                                         categories_to_keep=(1, {1}),
+                                         categories_to_check={1, 2},
+                                         delete=True,
+                                         generate_masks=True,
+                                         CCAgT_path=ccagt_ann_multi_path,
+                                         paddings='0',
+                                         check_if_images_have_annotations=True,
+                                         extensions=('.png', '.jpg'),
+                                         aux_file_path=aux_path,
+                                         overwrite=True)
+            assert out == 0
+            _, _ = capsys.readouterr()
+
+        # Already exist this subdataset
         out = main.create_subdataset(name='test',
                                      original_dir=tmp_dir,
                                      output_base=tmp_dir,
@@ -47,6 +71,7 @@ def test_create_subdataset(capsys, ccagt_ann_multi_path, shape):
         assert out == 1
         assert err[:33] == 'Already exist a dataset with name'
 
+        # Wrong original dataset path
         out = main.create_subdataset(name='test1',
                                      original_dir=mask_dir,
                                      output_base=tmp_dir,
@@ -66,6 +91,96 @@ def test_create_subdataset(capsys, ccagt_ann_multi_path, shape):
         assert out == 1
         assert err[:30] == 'Not found the original data at'
 
+        # try default location for annotations path, and not found the file
+        out = main.create_subdataset(name='test2',
+                                     original_dir=tmp_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=None,
+                                     extract=None,
+                                     categories_to_keep=None,
+                                     categories_to_check=None,
+                                     delete=False,
+                                     generate_masks=False,
+                                     CCAgT_path=None,
+                                     paddings='0',
+                                     check_if_images_have_annotations=False,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=True)
+
+        _, err = capsys.readouterr()
+        assert out == 1
+        assert err[:33] == 'Not found the annotations file at'
+
+        # Wrong choice for the removal process
+        out = main.create_subdataset(name='test3',
+                                     original_dir=tmp_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=None,
+                                     extract=None,
+                                     categories_to_keep=(-1, {1}),
+                                     categories_to_check={1, 2},
+                                     delete=False,
+                                     generate_masks=False,
+                                     CCAgT_path=ccagt_ann_multi_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=False,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=False)
+
+        assert out == 1
+        _, err = capsys.readouterr()
+        assert err == 'Unexpected choice for the type of removal proccess.\n'
+
+        # Cover nothing to delete after check_if_images_have_annotations
+        ccagt_ann_multi.df = ccagt_ann_multi.df.loc[ccagt_ann_multi.df['image_id'] == 1]
+        ccagt_ann_path = os.path.join(tmp_dir, 'CCAgT.parquet.gzip')
+        ori_test4 = os.path.join(tmp_dir, 'oritest4')
+        ori_test4_img_dir = os.path.join(ori_test4, 'images')
+        os.makedirs(ori_test4_img_dir, exist_ok=True)
+        bn_img = ccagt_ann_multi.df['image_name'].to_numpy()[0] + '.jpg'
+        shutil.copy2(os.path.join(img_dir, bn_img), os.path.join(ori_test4_img_dir, bn_img))
+        ccagt_ann_multi.to_parquet(ccagt_ann_path)
+
+        out = main.create_subdataset(name='test4',
+                                     original_dir=ori_test4,
+                                     output_base=tmp_dir,
+                                     slice_images=None,
+                                     extract=None,
+                                     categories_to_keep=None,
+                                     categories_to_check=None,
+                                     delete=True,
+                                     generate_masks=False,
+                                     CCAgT_path=ccagt_ann_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=True,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=False)
+        assert out == 0
+        _, _ = capsys.readouterr()
+
+        # Cover early stop because don't have any annotation after removal proccess
+        out = main.create_subdataset(name='test5',
+                                     original_dir=tmp_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=None,
+                                     extract=None,
+                                     categories_to_keep=(1, {}),
+                                     categories_to_check=None,
+                                     delete=True,
+                                     generate_masks=False,
+                                     CCAgT_path=ccagt_ann_multi_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=True,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=False)
+        assert out == 1
+        _, err = capsys.readouterr()
+        assert err == 'The annotations file has none annotation, just finishing the process!\n'
+
 
 @pytest.mark.slow
 def test_create_subdataset_with_slice(shape, ccagt_ann_multi_path, ccagt_ann_multi_image_names):
@@ -77,7 +192,7 @@ def test_create_subdataset_with_slice(shape, ccagt_ann_multi_path, ccagt_ann_mul
                                      output_base=tmp_dir,
                                      slice_images=(1, 2),
                                      extract=None,
-                                     categories_to_keep={1},
+                                     categories_to_keep=(0, {1}),
                                      categories_to_check={99},
                                      delete=True,
                                      generate_masks=False,
@@ -95,7 +210,7 @@ def test_create_subdataset_with_slice(shape, ccagt_ann_multi_path, ccagt_ann_mul
                                      output_base=tmp_dir,
                                      slice_images=(1, 2),
                                      extract=None,
-                                     categories_to_keep={1},
+                                     categories_to_keep=(0, {1}),
                                      categories_to_check={99},
                                      delete=True,
                                      generate_masks=True,
@@ -112,7 +227,7 @@ def test_create_subdataset_with_slice(shape, ccagt_ann_multi_path, ccagt_ann_mul
                                      output_base=tmp_dir,
                                      slice_images=(1, 2),
                                      extract=None,
-                                     categories_to_keep={1},
+                                     categories_to_keep=(0, {1}),
                                      categories_to_check={99},
                                      delete=True,
                                      generate_masks=False,
@@ -169,8 +284,16 @@ def test_main_help_other_command():
 
 def test_main_create_subdataset(shape, ccagt_ann_multi_path, ccagt_ann_multi_image_names):
     with create.ImageMaskFiles(shape[0], shape[1], ccagt_ann_multi_image_names) as paths:
-        tmp_dir, masks_dir, _ = paths
+        tmp_dir, _, _ = paths
         out = main.main(['create-subdataset', '--name', 'example', '--original', tmp_dir, '--output', tmp_dir, '--labels',
                          ccagt_ann_multi_path])
+        assert out == 0
 
+        out = main.main(['create-subdataset', '--name', 'example1', '--original', tmp_dir, '--output', tmp_dir, '--labels',
+                         ccagt_ann_multi_path, '--remove-images-without', '1'])
+        assert out == 0
+
+        out = main.main(['create-subdataset', '--name', 'example2', '--original', tmp_dir, '--output', tmp_dir, '--labels',
+                         ccagt_ann_multi_path, '--remove-annotations-without', '1', '--check-if-all-have-at-least-one-of',
+                         '1'])
         assert out == 0

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,60 +1,152 @@
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from CCAgT_utils import main
 from testing import create
 
 
-def test_create_subdataset(capsys, shape):
+def test_create_subdataset(capsys, ccagt_ann_multi_path, shape):
     with create.ImageMaskFiles(shape[0], shape[1], ['A_example']) as paths:
-        tmp_dir, masks_dir, _ = paths
-        out = main.create_subdataset('test', tmp_dir, tmp_dir, None, None, None, None, False, None, '0')
+        tmp_dir, mask_dir, _ = paths
+        out = main.create_subdataset(name='test',
+                                     original_dir=tmp_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=None,
+                                     extract=None,
+                                     categories_to_keep=None,
+                                     categories_to_check=None,
+                                     delete=False,
+                                     generate_masks=False,
+                                     CCAgT_path=ccagt_ann_multi_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=False,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=False)
+
         assert out == 0
         _, _ = capsys.readouterr()
 
-        out = main.create_subdataset('test', tmp_dir, tmp_dir, None, None, None, None, False, None, '0')
+        out = main.create_subdataset(name='test',
+                                     original_dir=tmp_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=None,
+                                     extract=None,
+                                     categories_to_keep=None,
+                                     categories_to_check=None,
+                                     delete=False,
+                                     generate_masks=False,
+                                     CCAgT_path=ccagt_ann_multi_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=False,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=False)
         _, err = capsys.readouterr()
         assert out == 1
         assert err[:33] == 'Already exist a dataset with name'
 
-        out = main.create_subdataset('test1', masks_dir, tmp_dir, None, None, None, None, False, None, '0')
+        out = main.create_subdataset(name='test1',
+                                     original_dir=mask_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=None,
+                                     extract=None,
+                                     categories_to_keep=None,
+                                     categories_to_check=None,
+                                     delete=False,
+                                     generate_masks=False,
+                                     CCAgT_path=ccagt_ann_multi_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=False,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=False)
         _, err = capsys.readouterr()
         assert out == 1
-        assert err[:36] == 'Do not found the original dataset at'
+        assert err[:30] == 'Not found the original data at'
 
 
 @pytest.mark.slow
-def test_create_subdataset_with_slice(shape):
-    with create.ImageMaskFiles(shape[0], shape[1], ['A_example']) as paths:
-        tmp_dir, masks_dir, _ = paths
-        out = main.create_subdataset('test', tmp_dir, tmp_dir, (1, 2), None, {1}, {99}, True, None, '0')
+def test_create_subdataset_with_slice(shape, ccagt_ann_multi_path, ccagt_ann_multi_image_names):
+
+    with create.ImageMaskFiles(shape[0], shape[1], ccagt_ann_multi_image_names) as paths:
+        tmp_dir, _, _ = paths
+        out = main.create_subdataset(name='test',
+                                     original_dir=tmp_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=(1, 2),
+                                     extract=None,
+                                     categories_to_keep={1},
+                                     categories_to_check={99},
+                                     delete=True,
+                                     generate_masks=False,
+                                     CCAgT_path=ccagt_ann_multi_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=False,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=False)
+
         assert out == 0
 
-        out = main.create_subdataset('test1', tmp_dir, tmp_dir, (1, 2), None, {1}, {1}, True, None, '0')
+        out = main.create_subdataset('test1',
+                                     original_dir=tmp_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=(1, 2),
+                                     extract=None,
+                                     categories_to_keep={1},
+                                     categories_to_check={99},
+                                     delete=True,
+                                     generate_masks=True,
+                                     CCAgT_path=ccagt_ann_multi_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=False,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=True)
         assert out == 0
 
-        out = main.create_subdataset('test2', tmp_dir, tmp_dir, (1, 2), None, {1}, {99}, False, None, '0')
+        out = main.create_subdataset('test2',
+                                     original_dir=tmp_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=(1, 2),
+                                     extract=None,
+                                     categories_to_keep={1},
+                                     categories_to_check={99},
+                                     delete=True,
+                                     generate_masks=False,
+                                     CCAgT_path=ccagt_ann_multi_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=False,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=False)
         assert out == 0
 
 
 @pytest.mark.slow
-def test_create_subdataset_with_extraction(capsys, shape, ccagt_ann_single_nucleus):
-    img_name = ccagt_ann_single_nucleus.df.iloc[0]['image_name']
-    with create.ImageMaskFiles(shape[0], shape[1], [img_name]) as paths:
+def test_create_subdataset_with_extraction(capsys, shape, ccagt_ann_multi_path, ccagt_ann_multi_image_names):
+    with create.ImageMaskFiles(shape[0], shape[1], ccagt_ann_multi_image_names) as paths:
         tmp_dir, masks_dir, _ = paths
-        labels_path = os.path.join(tmp_dir, 'labels.parquet.gzip')
-        ccagt_ann_single_nucleus.to_parquet(labels_path)
-        out = main.create_subdataset('test', tmp_dir, tmp_dir, None, {1}, None, None, None, labels_path, '0')
+
+        out = main.create_subdataset('test',
+                                     original_dir=tmp_dir,
+                                     output_base=tmp_dir,
+                                     slice_images=None,
+                                     extract={1},
+                                     categories_to_keep=None,
+                                     categories_to_check=None,
+                                     delete=True,
+                                     generate_masks=False,
+                                     CCAgT_path=ccagt_ann_multi_path,
+                                     paddings='0',
+                                     check_if_images_have_annotations=False,
+                                     extensions=('.png', '.jpg'),
+                                     aux_file_path=None,
+                                     overwrite=False)
         assert out == 0
         _, _ = capsys.readouterr()
-
-        out = main.create_subdataset('test1', tmp_dir, tmp_dir, None, {1}, None, None, None, None, '0')
-        assert out == 1
-        _, err = capsys.readouterr()
-        assert err[:80] == 'When using `--extract`, please specify the labels files with `--labels` argument'
 
 
 def test_not_implemented_command():
@@ -75,9 +167,10 @@ def test_main_help_other_command():
         main.main(['help', 'create-subdataset'])
 
 
-def test_main_create_subdataset(shape):
-    with create.ImageMaskFiles(shape[0], shape[1], ['A_example']) as paths:
+def test_main_create_subdataset(shape, ccagt_ann_multi_path, ccagt_ann_multi_image_names):
+    with create.ImageMaskFiles(shape[0], shape[1], ccagt_ann_multi_image_names) as paths:
         tmp_dir, masks_dir, _ = paths
-        out = main.main(['create-subdataset', '--name', 'example', '--original', tmp_dir, '--output', tmp_dir])
+        out = main.main(['create-subdataset', '--name', 'example', '--original', tmp_dir, '--output', tmp_dir, '--labels',
+                         ccagt_ann_multi_path])
 
         assert out == 0

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -294,6 +294,6 @@ def test_main_create_subdataset(shape, ccagt_ann_multi_path, ccagt_ann_multi_ima
         assert out == 0
 
         out = main.main(['create-subdataset', '--name', 'example2', '--original', tmp_dir, '--output', tmp_dir, '--labels',
-                         ccagt_ann_multi_path, '--remove-annotations-without', '1', '--check-if-all-have-at-least-one-of',
+                         ccagt_ann_multi_path, '--remove-annotations-different', '1', '--check-if-all-have-at-least-one-of',
                          '1'])
         assert out == 0

--- a/tests/prepare_test.py
+++ b/tests/prepare_test.py
@@ -17,54 +17,75 @@ def test_clean_images_and_masks(shape):
         assert os.path.isfile(os.path.join(images_dir, 'A', 'A_example_2.jpg')) is False
 
 
-def test_extract_category_from_image_file(shape, annotations_ex):
+def test_extract_category(shape, annotations_ex):
     with create.ImageMaskFiles(shape[0], shape[1], ['A_example'], create_image=False) as paths:
         tmp_dir, masks_dir, _ = paths
         msk_path = os.path.join(masks_dir, 'A_example.png')
 
-        extracted_quantity = prepare.extract_category_from_image_file(msk_path, tmp_dir, [annotations_ex[0]], 0)
+        extracted_quantity, annotations_items = prepare.extract_category(msk_path,
+                                                                         tmp_dir,
+                                                                         [(annotations_ex[0], [annotations_ex[1]])],
+                                                                         0)
 
         assert extracted_quantity == 1
+        assert len(annotations_items) == 2
+        assert all('image_name' in x for x in annotations_items)
+        assert all('geometry' in x for x in annotations_items)
+        assert all('category_id' in x for x in annotations_items)
+        image_name_out = [x['image_name'] for x in annotations_items]
+        assert all('A_example_1_1' == x for x in image_name_out)
+        assert [x['category_id'] for x in annotations_items] == [1, 2]
+        assert annotations_items[0]['geometry'].equals(annotations_ex[0].geometry)
+        assert annotations_items[1]['geometry'].equals(annotations_ex[1].geometry)
         assert os.path.isfile(os.path.join(tmp_dir, 'A_example_1_1.png'))
 
 
-def test_single_core_extract_image_and_masks(shape, ccagt_df_single_nucleus):
-    img_name = ccagt_df_single_nucleus.iloc[0]['image_name']
+def test_single_core_extract_image_and_annotations(shape, ccagt_ann_single_nucleus):
+    img_name = ccagt_ann_single_nucleus.df.iloc[0]['image_name']
     slide = img_name.split('_')[0]
     with create.ImageMaskFiles(shape[0], shape[1], [img_name]) as paths:
-        tmp_dir, masks_dir, images_dir = paths
+        tmp_dir, _, images_dir = paths
 
         imgs = {img_name: os.path.join(images_dir, f'{img_name}.jpg')}
-        msks = {img_name: os.path.join(masks_dir, f'{img_name}.png')}
-
-        masks_dir_out = os.path.join(masks_dir, f'{slide}')
-        os.makedirs(masks_dir_out)
 
         images_dir_out = os.path.join(images_dir, f'{slide}')
         os.makedirs(images_dir_out)
 
-        extracted_quantity = prepare.single_core_extract_image_and_masks(imgs, msks, ccagt_df_single_nucleus, tmp_dir, 0)
+        extracted_quantity, annotations_items = prepare.single_core_extract_image_and_annotations(imgs,
+                                                                                                  ccagt_ann_single_nucleus,
+                                                                                                  {1},
+                                                                                                  tmp_dir,
+                                                                                                  0)
 
-        assert extracted_quantity == (1, 1)
+        assert extracted_quantity == 1
+        assert len(annotations_items) == 1
 
-        extracted_quantity = prepare.single_core_extract_image_and_masks({}, {}, ccagt_df_single_nucleus, tmp_dir, 0)
+        extracted_quantity, annotations_items = prepare.single_core_extract_image_and_annotations(imgs,
+                                                                                                  ccagt_ann_single_nucleus,
+                                                                                                  {0},
+                                                                                                  tmp_dir,
+                                                                                                  0)
 
-        assert extracted_quantity == (0, 0)
+        assert extracted_quantity == 0
+        assert len(annotations_items) == 0
 
 
-def test_extract_image_and_mask_by_category(capsys, shape, ccagt_ann_single_nucleus):
-    img_name = ccagt_ann_single_nucleus.df.iloc[0]['image_name']
-    slide = img_name.split('_')[0]
-    with create.ImageMaskFiles(shape[0], shape[1], [img_name]) as paths:
-        tmp_dir, masks_dir, images_dir = paths
-        labels_path = os.path.join(tmp_dir, 'labels.parquet.gzip')
-        ccagt_ann_single_nucleus.to_parquet(labels_path)
+def test_extract_image_and_mask_by_category(shape,
+                                            ccagt_ann_multi_path,
+                                            ccagt_ann_multi_image_names,
+                                            ccagt_df_multi):
+    df_filtered = ccagt_df_multi[ccagt_df_multi['category_id'] == 1]
+    with create.ImageMaskFiles(shape[0], shape[1], ccagt_ann_multi_image_names) as paths:
+        tmp_dir, _, images_dir = paths
 
-        prepare.extract_image_and_mask_by_category(images_dir, masks_dir, tmp_dir, {1}, labels_path, 0)
+        prepare.extract_image_and_annotations_by_category(images_dir, tmp_dir, {1}, ccagt_ann_multi_path, 0)
 
-        assert os.path.isfile(os.path.join(masks_dir, slide, f'{img_name}_1_1.png'))
-        _, _ = capsys.readouterr()
-
-        prepare.extract_image_and_mask_by_category(images_dir, masks_dir, tmp_dir, {99}, labels_path, 0)
-        out, _ = capsys.readouterr()
-        assert out[:34] == 'Nothing to process with categories'
+        assert all(
+            os.path.isfile(
+                os.path.join(
+                    images_dir, row['image_name'].split('_')[0],
+                    f'{row["image_name"]}_{row["category_id"]}_1.jpg'
+                )
+            )
+            for _, row in df_filtered.iterrows()
+        )

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import os
+from collections import Counter
 
 import pytest
+from shapely import affinity
 
 from CCAgT_utils import slice
+from CCAgT_utils.types.annotation import Annotation
 from testing import create
 
 
@@ -20,22 +23,34 @@ def test_slice_image(shape):
 
 
 @pytest.mark.slow
-def test_image_with_annotation(shape, annotations_ex):
+def test_image_with_annotation(shape, annotations_ex, cluster_ex):
     with create.ImageMaskFiles(shape[0], shape[1], ['A_example']) as paths:
         tmp_dir, _, images_dir = paths
         img_path = os.path.join(images_dir, 'A_example.jpg')
 
-        sliced_quantity, annotations_items = slice.image_with_annotation(img_path, tmp_dir, annotations_ex, 2, 2)
+        # test stop when take all annotations, and slice annotations into others (if a annotation intersects the new size)
+        sliced_quantity, annotations_items = slice.image_with_annotation(img_path, tmp_dir, annotations_ex, 100, 100)
 
-        assert sliced_quantity == 1
+        assert sliced_quantity == 6
         assert all('image_name' in x for x in annotations_items)
         assert all('geometry' in x for x in annotations_items)
         assert all('category_id' in x for x in annotations_items)
         assert os.path.isfile(os.path.join(tmp_dir, 'A_example_1.jpg'))
 
+        # test stops when finish the slices, and copy the annotation (if a annotation is completely inside of the new size)
+        ann_items = annotations_ex[:]
+        ann_items.append(Annotation(affinity.translate(cluster_ex, -9999, -9999), 2))
+        sliced_quantity, annotations_items = slice.image_with_annotation(img_path, tmp_dir, ann_items, 1, 2)
+
+        assert sliced_quantity == 1
+        assert len(annotations_items) == len(annotations_ex)
+        assert all('image_name' in x for x in annotations_items)
+        assert all('geometry' in x for x in annotations_items)
+        assert all('category_id' in x for x in annotations_items)
+
 
 @pytest.mark.slow
-def test_single_core_image_and_annotations(shape, ccagt_df_single_nucleus):
+def test_single_core_image_and_annotations(shape, ccagt_df_single_nucleus, cluster_ex):
     ccagt_df_single_nucleus['image_name'] = 'A_example'
     with create.ImageMaskFiles(shape[0], shape[1], ['A_example']) as paths:
         tmp_dir, _, images_dir = paths
@@ -51,13 +66,14 @@ def test_single_core_image_and_annotations(shape, ccagt_df_single_nucleus):
                                                                                      2,
                                                                                      2)
         assert sliced_quantity == 1
+        assert len(annotations_items) == 1
         assert os.path.isfile(os.path.join(images_dir_out, 'A_example_1.jpg'))
 
 
 @pytest.mark.slow
-def test_slice_image_and_masks(shape, ccagt_ann_multi_image_names, ccagt_ann_multi_path):
+def test_slice_images_and_annotations(shape, ccagt_ann_multi_image_names, ccagt_ann_multi_path):
     with create.ImageMaskFiles(shape[0], shape[1], ccagt_ann_multi_image_names) as paths:
-        tmp_dir, masks_dir, images_dir = paths
+        tmp_dir, _, images_dir = paths
         out_label = os.path.join(tmp_dir, 'CCAgT.parquet.gzip')
         slice.images_and_annotations(dir_images=images_dir,
                                      annotations_path=ccagt_ann_multi_path,
@@ -68,5 +84,6 @@ def test_slice_image_and_masks(shape, ccagt_ann_multi_image_names, ccagt_ann_mul
                                      extension=('.png', '.jpg'))
 
         slides = [x.split('_')[0] for x in ccagt_ann_multi_image_names]
+        slides_counter = Counter(slides)
         assert os.path.isfile(out_label)
-        assert all(len(os.listdir(os.path.join(tmp_dir, 'images', s))) == 1 for s in slides)
+        assert all(len(os.listdir(os.path.join(tmp_dir, 'images', s))) == qtd for s, qtd in slides_counter.items())

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -20,39 +20,53 @@ def test_slice_image(shape):
 
 
 @pytest.mark.slow
-def test_single_core_image_and_masks(shape):
+def test_image_with_annotation(shape, annotations_ex):
     with create.ImageMaskFiles(shape[0], shape[1], ['A_example']) as paths:
-        tmp_dir, masks_dir, images_dir = paths
+        tmp_dir, _, images_dir = paths
+        img_path = os.path.join(images_dir, 'A_example.jpg')
+
+        sliced_quantity, annotations_items = slice.image_with_annotation(img_path, tmp_dir, annotations_ex, 2, 2)
+
+        assert sliced_quantity == 1
+        assert all('image_name' in x for x in annotations_items)
+        assert all('geometry' in x for x in annotations_items)
+        assert all('category_id' in x for x in annotations_items)
+        assert os.path.isfile(os.path.join(tmp_dir, 'A_example_1.jpg'))
+
+
+@pytest.mark.slow
+def test_single_core_image_and_annotations(shape, ccagt_df_single_nucleus):
+    ccagt_df_single_nucleus['image_name'] = 'A_example'
+    with create.ImageMaskFiles(shape[0], shape[1], ['A_example']) as paths:
+        tmp_dir, _, images_dir = paths
 
         imgs = {'A_example': os.path.join(images_dir, 'A_example.jpg')}
-        msks = {'A_example': os.path.join(masks_dir, 'A_example.png')}
-
-        masks_dir_out = os.path.join(masks_dir, 'A')
-        os.makedirs(masks_dir_out)
 
         images_dir_out = os.path.join(images_dir, 'A')
         os.makedirs(images_dir_out)
 
-        sliced_quantity = slice.single_core_image_and_masks(imgs, msks, tmp_dir, 1, 2)
-
-        assert sliced_quantity == (2, 2)
-        assert os.path.isfile(os.path.join(masks_dir_out, 'A_example_1.png'))
-        assert os.path.isfile(os.path.join(masks_dir_out, 'A_example_2.png'))
+        sliced_quantity, annotations_items = slice.single_core_image_and_annotations(imgs,
+                                                                                     ccagt_df_single_nucleus,
+                                                                                     tmp_dir,
+                                                                                     2,
+                                                                                     2)
+        assert sliced_quantity == 1
         assert os.path.isfile(os.path.join(images_dir_out, 'A_example_1.jpg'))
-        assert os.path.isfile(os.path.join(images_dir_out, 'A_example_2.jpg'))
-
-        msks = {}
-        sliced_quantity = slice.single_core_image_and_masks(imgs, msks, tmp_dir, 1, 2)
-        assert sliced_quantity == (2, 0)
 
 
 @pytest.mark.slow
-def test_slice_image_and_masks(shape):
-    with create.ImageMaskFiles(shape[0], shape[1], ['A_example']) as paths:
+def test_slice_image_and_masks(shape, ccagt_ann_multi_image_names, ccagt_ann_multi_path):
+    with create.ImageMaskFiles(shape[0], shape[1], ccagt_ann_multi_image_names) as paths:
         tmp_dir, masks_dir, images_dir = paths
-        slice.images_and_masks(images_dir, masks_dir, tmp_dir, 1, 2, extension=('.png', '.jpg'))
+        out_label = os.path.join(tmp_dir, 'CCAgT.parquet.gzip')
+        slice.images_and_annotations(dir_images=images_dir,
+                                     annotations_path=ccagt_ann_multi_path,
+                                     dir_output=tmp_dir,
+                                     output_annotations_path=out_label,
+                                     h_quantity=1,
+                                     v_quantity=2,
+                                     extension=('.png', '.jpg'))
 
-        assert os.path.isfile(os.path.join(masks_dir, 'A', 'A_example_1.png'))
-        assert os.path.isfile(os.path.join(masks_dir, 'A', 'A_example_2.png'))
-        assert os.path.isfile(os.path.join(images_dir, 'A', 'A_example_1.jpg'))
-        assert os.path.isfile(os.path.join(images_dir, 'A', 'A_example_2.jpg'))
+        slides = [x.split('_')[0] for x in ccagt_ann_multi_image_names]
+        assert os.path.isfile(out_label)
+        assert all(len(os.listdir(os.path.join(tmp_dir, 'images', s))) == 1 for s in slides)

--- a/tests/split_test.py
+++ b/tests/split_test.py
@@ -26,9 +26,9 @@ def test_tvt_by_nors(ccagt_ann_multi, ccagt_df_multi, categories_infos):
     ccagt_ann_multi.df['slide_id'] = ccagt_ann_multi.get_slide_id()
     out = split.tvt_by_nors(ccagt_ann_multi, categories_infos, (0.6, 0.2, 0.2), seed=6547)
 
-    assert out[0] == {8, 2, 5, 6}
-    assert out[1] == {1, 4}
-    assert out[2] == {3, 7}
+    assert out[0] == {3, 6, 7}
+    assert out[1] == {2, 5}
+    assert out[2] == {1, 4, 8}
 
 
 def test_tvt_by_nors_wrong_size(ccagt_ann_multi, categories_infos):


### PR DESCRIPTION
Change to work based on the annotations and generate the masks at the end of the process

`load original annotations`
1. Remove without the selected categories
  1.1 [x] delete annotations
`save the annotations at the new dataset`
2. prepare images
  2.1. slice
    2.1.1 [x] slice images
    2.1.2 [x] slice annotations
  2.2. extract
    2.2.1 [x] Generate images with each category centered
    2.2.2 [x] refactor annotations
  2.3. just copy
    2.3.1 [x] Copy images
`load annotations`
`run the pipeline of prepare the annotations` - needed because slice and extract process will modify the annotations

3. Check if all images have the selected categories
  3.1. Can just check into the annotations
    3.1.1 [x] Print the warning that have xx images without this
4. Check images that don't have any annotation [done]
5. if `--remove` is true, delete this images without annotations and without the selected categories
`save the annotations`  [done]
6. Generate the news masks  [done]
7. Describe the new dataset  [done]