### PR TITLE
Add `CLI` tool

### DIFF
--- a/CCAgT_utils/__main__.py
+++ b/CCAgT_utils/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from CCAgT_utils.commands.main import main
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/CCAgT_utils/commands/converter.py
+++ b/CCAgT_utils/commands/converter.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+
+def converter_command_parser(
+        subparsers: argparse._SubParsersAction[argparse.ArgumentParser] | None = None,
+) -> argparse.ArgumentParser:
+
+    if subparsers is not None:
+        parser = subparsers.add_parser('convert')
+    else:
+        parser = argparse.ArgumentParser(
+            prog='CCAgT-utils dataset converter command',
+        )
+
+    group_output = parser.add_argument_group(
+        'Define the output format desired.',
+    )
+
+    mexg_output = group_output.add_mutually_exclusive_group(required=True)
+    mexg_output.add_argument(
+        '--to-ccagt',
+        action='store_true',
+        help=(
+            'Convert the input data into the CCAgT dataset format. This '
+            'conversion is allowed from LabelBox format.'
+        ),
+    )
+
+    mexg_output.add_argument(
+        '--to-coco',
+        action='store_true',
+        help=(
+            'Convert the input data into the COCO dataset format. This '
+            'conversion is allowed from CCAgT format.'
+        ),
+    )
+
+    parser.add_argument(
+        '--target',
+        help='Define the target of the COCO format.',
+        choices=[
+            'object-detection', 'OD', 'panoptic-segmentation',
+            'PS', 'instance-segmentation', 'IS',
+        ],
+        required=False,
+    )
+
+    if subparsers is not None:
+        parser.set_defaults(func=converter_command)
+        parser.set_defaults(checker=check_arguments)
+
+    return parser
+
+
+def check_arguments(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+) -> None:
+    if args.to_coco and (args.target is None):
+        parser.error('--to-ccagt requires --target')
+
+
+def converter_command(
+    args: argparse.Namespace | None = None,
+) -> int:
+    # TODO:
+    raise NotImplementedError
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = converter_command_parser()
+    args = parser.parse_args(argv)
+    return converter_command(args)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/CCAgT_utils/commands/main.py
+++ b/CCAgT_utils/commands/main.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+from CCAgT_utils.commands.converter import converter_command_parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    parser = argparse.ArgumentParser(
+        prog='CCAgT utils CLI tools',
+        usage='CCAgT-utils <command> [<args>]',
+        description=(
+            'This tool will help you to convert CCAgT between different '
+            'datasets formats, to generate sub-datasets and in '
+            'the visualization of the dataset.'
+        ),
+    )
+
+    subparsers = parser.add_subparsers(
+        dest='command',
+        help='CCAgT-utils command helpers',
+    )
+
+    # Register commands
+    converter_command_parser(subparsers)
+
+    help = subparsers.add_parser(
+        'help',
+        help='Show help for a specific command.',
+    )
+    help.add_argument(
+        'help_cmd',
+        nargs='?',
+        help='Command to show help for.',
+    )
+
+    if len(argv) == 0:
+        argv = ['help']
+
+    args = parser.parse_args(argv)
+
+    if args.command == 'help' and args.help_cmd:
+        parser.parse_args([args.help_cmd, '--help'])
+    elif args.command == 'help':
+        parser.parse_args(['--help'])
+
+    # Run
+    if hasattr(args, 'checker'):
+        args.checker(parser, args)
+
+    if not hasattr(args, 'func'):
+        parser.print_help()
+        return 1
+
+    return args.func(args)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ exclude =
     tests*
     data*
 
+[options.entry_points]
+console_scripts =
+    CCAgT-utils = CCAgT_utils.commands.main:main
+
 [bdist_wheel]
 universal = True
 


### PR DESCRIPTION
Just add the base of the CLI tool, and a partial example (`CCAgT_utils/commands/converter.py`—need to implement the command yet) of how I expected to implement each command.

I kind of merge the old approach with the approach utilized at `hf/accelerate`.

The idea is to add new commands:

- at `CCAgT_utils/commands/converter.py`:
  - We will just import the command parser, and register it at the subparser.
- add a file at CCAgT_utils/commands/<command>.py`
  - This file should contain a command parser function (which will define the arguments for this command).
  - Also, should contain a function for the command itself. At the parser function, ensure to have `parser.set_defaults(func=<function_command>)` because it is needed to execute in the main function ("CCAgT_utils.commands.main:main").
  - If have the necessity to make mutually inclusive sets of option, create a `check_arguments` function for it (see the example at `commands/converter.py`). At the parser function, ensure to have `parser.set_defaults(checker=check_arguments)` because it is needed to execute in the main function ("CCAgT_utils.commands.main:main").
 



(Tests need to be added)
