### PR TITLE
fix iter for series

### DIFF
--- a/CCAgT_utils/converters/CCAgT.py
+++ b/CCAgT_utils/converters/CCAgT.py
@@ -209,7 +209,7 @@ class CCAgT():
         geo: Polygon,
         geometries: pd.Series,
     ) -> bool:
-        for _, g in geometries.iteritems():
+        for _, g in geometries.items():
             if geo.intersects(g):
                 return True
         return False


### PR DESCRIPTION
ref https://pandas.pydata.org/pandas-docs/version/1.5/reference/api/pandas.DataFrame.iteritems.html

> Deprecated since version 1.5.0: iteritems is deprecated and will be removed in a future version. Use .items instead.